### PR TITLE
add ability to display only stacks of tasks under given pid

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,14 @@ use std::{collections::HashMap, fs, path, rc::Rc};
 struct Options {
     include_kernel: bool,
     include_user: bool,
+    tasks_of_proc: bool,
+    tasks_procs: Vec<usize>,
 }
 
 fn usage() {
     eprintln!("Usage: stacks [ku]");
     eprintln!("         k: only include kernel threads");
+    eprintln!("         t: only parse threads of given process");
     eprintln!("         u: only include user threads");
 }
 
@@ -16,21 +19,49 @@ impl Options {
         Options {
             include_kernel: true,
             include_user: true,
+            tasks_of_proc: false,
+            tasks_procs: Vec::new(),
         }
     }
 
     fn apply(&mut self, opts: Vec<String>) {
+        let mut count: usize = 1;
         for s in opts.iter().skip(1) {
-            for ch in s.chars() {
-                match ch {
-                    'k' => self.include_user = false,
-                    'u' => self.include_kernel = false,
+            if count == 1 {
+                for ch in s.chars() {
+                    match ch {
+                        'k' => self.include_user = false,
+                        't' => {
+                            if opts.len() >= 3 {
+                                self.tasks_of_proc = true;
+                            } else {
+                                eprintln!("'t' specified without pid");
+                                usage();
+                                std::process::exit(1);
+                            }
+                        },
+                        'u' => self.include_kernel = false,
+                        _ => {
+                            usage();
+                            std::process::exit(1);
+                        }
+                    }
+                }
+            } else if self.tasks_of_proc {
+                let curr_proc: usize = match s.trim().parse() {
+                    Ok(num) if num > 0 => num,
                     _ => {
+                        eprintln!("invalid pid specified: '{}'", s.trim());
                         usage();
                         std::process::exit(1);
                     }
+                };
+                if count == 2 {
+                    self.tasks_procs = Vec::new();
                 }
+                self.tasks_procs.push(curr_proc);
             }
+            count += 1;
         }
     }
 }
@@ -130,15 +161,10 @@ fn display(p: &HashMap<String, Vec<Rc<ProcEntry>>>) {
     }
 }
 
-fn main() {
-    let proc_path = path::Path::new("/proc");
-
-    let mut proc_hash: HashMap<String, Vec<Rc<ProcEntry>>> = HashMap::new();
-
-    let mut options = Options::default_options();
-    options.apply(std::env::args().collect());
-
-    for entry in fs::read_dir(proc_path).unwrap() {
+fn process_proc_path(options: &Options,
+                    path: &path::Path, hmap: &mut HashMap<String,
+                    Vec<Rc<ProcEntry>>>) {
+    for entry in fs::read_dir(path).unwrap() {
         let entry = entry.unwrap();
 
         let proc_ent = match get_proc_ent(&options, &entry.path()) {
@@ -148,10 +174,31 @@ fn main() {
 
         let proc_ent = Rc::new(proc_ent);
 
-        proc_hash
+        hmap
             .entry(proc_ent.stack.clone())
             .and_modify(|v| v.push(Rc::clone(&proc_ent)))
             .or_insert(vec![Rc::clone(&proc_ent)]);
+    }
+}
+
+fn main() {
+    let mut options = Options::default_options();
+    options.apply(std::env::args().collect());
+
+    let mut proc_path_bases: Vec<String> = Vec::new();
+    if options.tasks_of_proc {
+        for pid in &options.tasks_procs {
+            proc_path_bases.push(format!("/proc/{}/task", pid));
+        }
+    } else {
+        proc_path_bases.push(String::from("/proc"));
+    }
+
+    let mut proc_hash: HashMap<String, Vec<Rc<ProcEntry>>> = HashMap::new();
+
+    for path in proc_path_bases {
+        let proc_path = path::Path::new(&path);
+        process_proc_path(&options, &proc_path, &mut proc_hash);
     }
 
     display(&proc_hash);


### PR DESCRIPTION
Previously, `stacks` would gather information for *every* pid with an entry in `/proc/` (further filtered by kernel/user thread).

This change allows specifying one or more pid whose entry is in `/proc/` such that `stacks` will only gather information related to tasks that are children of the given pid(s).